### PR TITLE
Add armhf support for cross compilation

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.arm-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[target.arm-unknown-linux-gnueabihf]
+image = "rustcross/arm-unknown-linux-gnueabihf"


### PR DESCRIPTION
So I tried cross compiling using the readme

```
cross build --target=arm-unknown-linux-gnueabi --release --example raspberry_pi_inky_phat --features examples
```

And a binary did result, but segfaulted on my raspberry pi zero w. The resulting file format is:

```
ELF 32-bit LSB pie executable ARM, EABI5 version 1 (SYSV), dynamically linked, 
interpreter /lib/ld-linux.so.3, for GNU/Linux 2.6.32, 
BuildID[sha1]=106da3de504ff660e85093b399132de00f484060, with debug_info, not stripped
```

When I tried using `gnueabihf`, and pointed the cross tool to `rustcross/arm-unknown-linux-gnueabihf`, the resulting file format is:

```
ELF 32-bit LSB pie executable ARM, EABI5 version 1 (SYSV), dynamically linked, 
interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 2.6.26, BuildID[sha1]=e7943ad7ed53c12c384d60981761686e6468658f, with debug_info, not stripped
```

I am new to cross compiling, so I am not sure if this is some other problem with my pi, but would you mind trying out both and seeing if this is helpful?