### PR TITLE
update to hal v2 traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,23 +18,23 @@ travis-ci = { repository = "wezm/ssd1675" }
 codecov = { repository = "wezm/ssd1675" }
 
 [dependencies]
-libm = "0.1.2"
+libm = "0.2.1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
-version = "0.2.2"
+version = "0.2.3"
 
 [dependencies.embedded-graphics]
 optional = true
-version = "0.4.4"
+version = "0.5.2"
 
 [dependencies.linux-embedded-hal]
 optional = true
-version = "0.2.1"
+version = "0.3.0"
 
 [dependencies.profont]
 optional = true
-version = "0.1"
+version = "0.3.0"
 
 [features]
 default = ["graphics"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,16 @@
+use core::fmt::{self, Debug};
+use hal::digital::v2::OutputPin;
+
+pub enum Error<GPIO: OutputPin> {
+    /// A GPIO could not be set.
+    Gpio(GPIO::Error),
+}
+
+impl<GPIO: OutputPin> Debug for Error<GPIO>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Gpio(_) => write!(f, "GPIO error"),
+        }
+    }
+}

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -153,7 +153,7 @@ where
 {
     fn draw<T>(&mut self, item_pixels: T)
     where
-        T: Iterator<Item = Pixel<Color>>,
+        T: IntoIterator<Item = Pixel<Color>>,
     {
         for Pixel(UnsignedCoord(x, y), colour) in item_pixels {
             if outside_display(

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -175,7 +175,7 @@ where
 mod tests {
     use self::embedded_graphics::coord::Coord;
     use self::embedded_graphics::prelude::*;
-    use self::embedded_graphics::primitives::Rect;
+    use self::embedded_graphics::primitives::Rectangle;
     use self::embedded_graphics::Drawing;
     use super::*;
     use {Builder, Color, Dimensions, Display, DisplayInterface, GraphicDisplay, Rotation};
@@ -279,8 +279,8 @@ mod tests {
                 GraphicDisplay::new(build_mock_display(), &mut black_buffer, &mut red_buffer);
 
             display.draw(
-                Rect::new(Coord::new(0, 0), Coord::new(2, 2))
-                    .with_stroke(Some(Color::White))
+                Rectangle::new(Coord::new(0, 0), Coord::new(2, 2))
+                    .stroke(Some(Color::White))
                     .into_iter(),
             );
         }
@@ -306,8 +306,8 @@ mod tests {
                 GraphicDisplay::new(build_mock_display(), &mut black_buffer, &mut red_buffer);
 
             display.draw(
-                Rect::new(Coord::new(0, 0), Coord::new(2, 2))
-                    .with_stroke(Some(Color::Red))
+                Rectangle::new(Coord::new(0, 0), Coord::new(2, 2))
+                    .stroke(Some(Color::Red))
                     .into_iter(),
             );
         }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,3 +1,4 @@
+use crate::Error;
 use hal;
 
 // Section 15.2 of the HINK-E0213A07 data sheet says to hold for 10ms
@@ -143,23 +144,23 @@ where
 {
     type Error = SPI::Error;
 
-    fn reset<D: hal::blocking::delay::DelayMs<u8>>(&mut self, delay: &mut D) {
-        self.reset.set_low();
+    fn reset<D: hal::blocking::delay::DelayMs<u8>>(&mut self, delay: &mut D){
+        self.reset.set_low().map_err::<Error<RESET>, _>(Error::Gpio).unwrap();
         delay.delay_ms(RESET_DELAY_MS);
-        self.reset.set_high();
+        self.reset.set_high().map_err::<Error<RESET>, _>(Error::Gpio).unwrap();
         delay.delay_ms(RESET_DELAY_MS);
     }
 
     fn send_command(&mut self, command: u8) -> Result<(), Self::Error> {
-        self.dc.set_low();
+        self.dc.set_low().map_err::<Error<DC>, _>(Error::Gpio).unwrap();
         self.write(&[command])?;
-        self.dc.set_high();
+        self.dc.set_high().map_err::<Error<DC>, _>(Error::Gpio).unwrap();
 
         Ok(())
     }
 
     fn send_data(&mut self, data: &[u8]) -> Result<(), Self::Error> {
-        self.dc.set_high();
+        self.dc.set_high().map_err::<Error<DC>, _>(Error::Gpio).unwrap();
         self.write(data)
     }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -96,10 +96,10 @@ pub struct Interface<SPI, CS, BUSY, DC, RESET> {
 impl<SPI, CS, BUSY, DC, RESET> Interface<SPI, CS, BUSY, DC, RESET>
 where
     SPI: hal::blocking::spi::Write<u8>,
-    CS: hal::digital::OutputPin,
-    BUSY: hal::digital::InputPin,
-    DC: hal::digital::OutputPin,
-    RESET: hal::digital::OutputPin,
+    CS: hal::digital::v2::OutputPin,
+    BUSY: hal::digital::v2::InputPin,
+    DC: hal::digital::v2::OutputPin,
+    RESET: hal::digital::v2::OutputPin,
 {
     /// Create a new Interface from embedded hal traits.
     pub fn new(spi: SPI, cs: CS, busy: BUSY, dc: DC, reset: RESET) -> Self {
@@ -136,10 +136,10 @@ where
 impl<SPI, CS, BUSY, DC, RESET> DisplayInterface for Interface<SPI, CS, BUSY, DC, RESET>
 where
     SPI: hal::blocking::spi::Write<u8>,
-    CS: hal::digital::OutputPin,
-    BUSY: hal::digital::InputPin,
-    DC: hal::digital::OutputPin,
-    RESET: hal::digital::OutputPin,
+    CS: hal::digital::v2::OutputPin,
+    BUSY: hal::digital::v2::InputPin,
+    DC: hal::digital::v2::OutputPin,
+    RESET: hal::digital::v2::OutputPin,
 {
     type Error = SPI::Error;
 
@@ -164,6 +164,9 @@ where
     }
 
     fn busy_wait(&self) {
-        while self.busy.is_high() {}
+        while match self.busy.is_high() {
+            Ok(x) => x,
+            _ => false,
+        } {}
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,12 +47,14 @@ mod color;
 pub mod command;
 pub mod config;
 pub mod display;
+pub mod error;
 pub mod graphics;
 pub mod interface;
 
 pub use color::Color;
 pub use config::Builder;
 pub use display::{Dimensions, Display, Rotation};
+pub use error::Error;
 pub use graphics::GraphicDisplay;
 pub use interface::DisplayInterface;
 pub use interface::Interface;


### PR DESCRIPTION
Updated to the hal digital v2 traits. The old traits are deprecated and a little harder to work with now. The only issue this introduced is the v2 traits return a result. You can't unwrap them without an error type specified, so right now I'm just ignoring the result. Could possibly do:
if let Some(_) = self.dc.set_low() {};
but it looks a little ugly to me.